### PR TITLE
Added validation rule for deadline so that the date format is Y-m-d

### DIFF
--- a/app/Http/Requests/ProjectRequest.php
+++ b/app/Http/Requests/ProjectRequest.php
@@ -24,7 +24,8 @@ class ProjectRequest extends Request {
         return [
             'name' => 'required|min:3|max:100',
             'slug' => 'required|alpha_dash|min:4|max:50',
-            'issue_prefix' => 'required|alpha|min:3|max:10'
+            'issue_prefix' => 'required|alpha|min:3|max:10',
+            'deadline' => 'sometimes|date_format:Y-m-d',
         ];
     }
 


### PR DESCRIPTION
Since the validation rule was missing altogether, I assumed that a deadline does not need to be given. Based on that, I added `'deadline' => 'sometimes|date_format:Y-m-d'` to the ProjectRequest.php file.